### PR TITLE
Change project to use a root-level cargo workspace and apply cargo fmt and cargo fix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+members = ["examples/*"]
+
+
+resolver = "2"
+
+[profile.release]
+opt-level = 2 # fast and small wasm

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,9 +9,13 @@ Once you have rust installed (see the [setup page](/setup)), here is how to run 
 # Do this once to get the code
 git clone https://github.com/appcove/egui.info.git
 
-# Here is how to run any example
-cd egui.info/examples/egui-101-basic
-cargo build
+# Enter the egui.info directory
+cd egui.info
+
+# Examples can be built with
+cargo build -p egui-101-basic
+# And run with
+cargo run -p egui-101-basic
 ```
 
 

--- a/examples/egui-101-basic/src/main.rs
+++ b/examples/egui-101-basic/src/main.rs
@@ -10,7 +10,7 @@ impl ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ctx.set_pixels_per_point(1.5);
 
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/examples/egui-101-menu/Cargo.toml
+++ b/examples/egui-101-menu/Cargo.toml
@@ -8,9 +8,3 @@ rust-version = "1.56"
 eframe = "0.24.0" # Gives us egui, epi and web+native backends
 
 
-[features]
-
-
-[profile.release]
-opt-level = 2 # fast and small wasm
-

--- a/examples/egui-101-menu/src/main.rs
+++ b/examples/egui-101-menu/src/main.rs
@@ -10,7 +10,7 @@ impl ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ctx.set_pixels_per_point(1.5);
 
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {

--- a/examples/egui-101-moving-circle/src/main.rs
+++ b/examples/egui-101-moving-circle/src/main.rs
@@ -23,7 +23,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Move the circle position
         self.cy += 0.7;
         self.cx += 0.25;

--- a/examples/egui-112-button-move-circle/src/main.rs
+++ b/examples/egui-112-button-move-circle/src/main.rs
@@ -25,7 +25,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Looks better on 4k montior
         ctx.set_pixels_per_point(1.5);
 

--- a/examples/egui-112-circle-follow-mouse/src/main.rs
+++ b/examples/egui-112-circle-follow-mouse/src/main.rs
@@ -17,7 +17,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // On each frame, set 1.5 pixels per point
         ctx.set_pixels_per_point(1.5);
 

--- a/examples/egui-112-keypress-move-circle/src/main.rs
+++ b/examples/egui-112-keypress-move-circle/src/main.rs
@@ -27,7 +27,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Looks better on 4k montior
         ctx.set_pixels_per_point(1.5);
 
@@ -89,8 +89,6 @@ impl eframe::App for ExampleApp {
 }
 
 fn main() -> eframe::Result<()> {
-    let app = ExampleApp::default();
-
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size((800.0, 800.0)),
         ..eframe::NativeOptions::default()

--- a/examples/egui-122-button-grid/src/main.rs
+++ b/examples/egui-122-button-grid/src/main.rs
@@ -21,7 +21,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ctx.set_pixels_per_point(1.5);
 
         egui::CentralPanel::default().show(ctx, |ui| {
@@ -34,8 +34,8 @@ impl eframe::App for ExampleApp {
 
             egui::Grid::new("grid").show(ui, |ui| {
                 let mut count = 0;
-                for i in 0..self.grid_size {
-                    for j in 0..self.grid_size {
+                for _i in 0..self.grid_size {
+                    for _j in 0..self.grid_size {
                         count += 1;
                         if count <= 9 {
                             if ui.button(format!(" 0{} ", count.to_string())).clicked() {

--- a/examples/egui-122-checkbox-functionality/src/main.rs
+++ b/examples/egui-122-checkbox-functionality/src/main.rs
@@ -31,7 +31,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Looks better on 4k montior
         ctx.set_pixels_per_point(1.5);
 

--- a/examples/egui-122-slider/src/main.rs
+++ b/examples/egui-122-slider/src/main.rs
@@ -25,7 +25,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Looks better on 4k montior
         ctx.set_pixels_per_point(1.5);
 

--- a/examples/egui-122-text-size/src/main.rs
+++ b/examples/egui-122-text-size/src/main.rs
@@ -35,7 +35,6 @@ impl eframe::App for ExampleApp {
             });
         });
         egui::CentralPanel::default().show(ctx, |ui| {
-            let mut fonts = egui::FontDefinitions::default();
             // Large button text:
             if self.selected == 1 {
                 ctx.style_mut(|style| {

--- a/examples/egui-144-ball-chaser-2-player/src/main.rs
+++ b/examples/egui-144-ball-chaser-2-player/src/main.rs
@@ -134,7 +134,7 @@ impl ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Looks better on 4k montior
         ctx.set_pixels_per_point(1.5);
 

--- a/examples/egui-144-clicker-game/src/main.rs
+++ b/examples/egui-144-clicker-game/src/main.rs
@@ -36,7 +36,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // On each frame, set 1.5 pixels per point
         ctx.set_pixels_per_point(1.5);
         ctx.set_pixels_per_point(1.5);

--- a/examples/egui-144-color-clicker/src/main.rs
+++ b/examples/egui-144-color-clicker/src/main.rs
@@ -48,7 +48,7 @@ impl Default for ExampleApp {
 }
 
 impl eframe::App for ExampleApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // On each frame, set 1.5 pixels per point
         ctx.set_pixels_per_point(1.5);
 

--- a/setup/index.md
+++ b/setup/index.md
@@ -70,13 +70,12 @@ git clone git@github.com:appcove/egui.info.git
 cd egui.info
 ```
 
-After git is finished cloning the repository, change directories into our example of a simple native Rust application and run cargo.
+After git is finished cloning the repository, run cargo with the example you want to run specified.
 
 Note: Upon running a Rust application for the first time, it can take considerable time to install all dependencies.
 
 ```bash
-cd examples/egui-example-native-basic
-cargo run
+cargo run -p egui-101-basic
 ```
 
 


### PR DESCRIPTION
Hi,
I have updated this project to use a cargo workspace instead of individual crates.
Now all of the crates use the same target/ directory at the root level and share compilation artifacts.
The individual examples can be built and run using the -p flag with the name of the example (i.e. `cargo run -p egui-101-basic`, no need to cd into its directory).
I have updated this to be reflected in the documentation.

In addition I have run `cargo fix` and `cargo fmt` on the entire project. `cargo build` shows that all the examples compile with no warnings or errors (I am using Win11).