### PR TITLE
Update eframe to version 0.27.2

### DIFF
--- a/examples/egui-101-basic/Cargo.toml
+++ b/examples/egui-101-basic/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-101-menu/Cargo.toml
+++ b/examples/egui-101-menu/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 
 

--- a/examples/egui-101-moving-circle/Cargo.toml
+++ b/examples/egui-101-moving-circle/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-112-button-move-circle/Cargo.toml
+++ b/examples/egui-112-button-move-circle/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-112-circle-follow-mouse/Cargo.toml
+++ b/examples/egui-112-circle-follow-mouse/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-112-keypress-move-circle-with-velocity/Cargo.toml
+++ b/examples/egui-112-keypress-move-circle-with-velocity/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-112-keypress-move-circle/Cargo.toml
+++ b/examples/egui-112-keypress-move-circle/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-button-grid/Cargo.toml
+++ b/examples/egui-122-button-grid/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-check-box/Cargo.toml
+++ b/examples/egui-122-check-box/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-checkbox-functionality/Cargo.toml
+++ b/examples/egui-122-checkbox-functionality/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 # rand = "0.8"
 

--- a/examples/egui-122-combo-box/Cargo.toml
+++ b/examples/egui-122-combo-box/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-multiple-choice/Cargo.toml
+++ b/examples/egui-122-multiple-choice/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-slider/Cargo.toml
+++ b/examples/egui-122-slider/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-122-text-size/Cargo.toml
+++ b/examples/egui-122-text-size/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 

--- a/examples/egui-144-ball-chaser-2-player/Cargo.toml
+++ b/examples/egui-144-ball-chaser-2-player/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 rand = "0.8"
 

--- a/examples/egui-144-circle-chaser/Cargo.toml
+++ b/examples/egui-144-circle-chaser/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 rand = "0.8"

--- a/examples/egui-144-clicker-game/Cargo.toml
+++ b/examples/egui-144-clicker-game/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 rand = "0.8"

--- a/examples/egui-144-color-clicker/Cargo.toml
+++ b/examples/egui-144-color-clicker/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.24.0" # Gives us egui, epi and web+native backends
+eframe = "0.27.2" # Gives us egui, epi and web+native backends
 rand = "0.8"
 

--- a/examples/egui-215-todo-list/Cargo.toml
+++ b/examples/egui-215-todo-list/Cargo.toml
@@ -7,4 +7,4 @@ rust-version = "1.56"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe = "0.24.0"
+eframe = "0.27.2"


### PR DESCRIPTION
Update eframe dependencies to latest version in all examples to enable building on Windows machines, resolving [issue 26](https://github.com/appcove/egui.info/issues/26).